### PR TITLE
Update ports-prod-2.sh

### DIFF
--- a/iptables/firewall/ports-prod-2.sh
+++ b/iptables/firewall/ports-prod-2.sh
@@ -45,6 +45,7 @@ iptables -A OUTPUT -m state --state NEW,ESTABLISHED -p tcp --dport 443 -j ACCEPT
 
 # LEITE eingehenden traffic auf Port 80 WEITER zum Webserver und zurueck
 iptables -A FORWARD -p tcp -d 192.168.0.221 --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A FORWARD -p tcp -s 192.168.0.221 --sport 80 -m state --state ESTABLISHED -j ACCEPT
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j DNAT --to-destination 192.168.0.221:80
 iptables -t nat -A POSTROUTING -p tcp -d 192.168.0.221 --dport 80 -j MASQUERADE
 

--- a/iptables/firewall/ports-prod-2.sh
+++ b/iptables/firewall/ports-prod-2.sh
@@ -44,34 +44,30 @@ iptables -A INPUT -m state --state ESTABLISHED -p tcp --sport 443 -j ACCEPT
 iptables -A OUTPUT -m state --state NEW,ESTABLISHED -p tcp --dport 443 -j ACCEPT
 
 # LEITE eingehenden traffic auf Port 80 WEITER zum Webserver und zurueck
-iptables -A FORWARD -p tcp -d 192.168.0.221 --dport 80 -j ACCEPT
+iptables -A FORWARD -p tcp -d 192.168.0.221 --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j DNAT --to-destination 192.168.0.221:80
 iptables -t nat -A POSTROUTING -p tcp -d 192.168.0.221 --dport 80 -j MASQUERADE
 
 # ERLAUBE traffic zu einem externen Outlook Exchange Server
-# Das Verwenden von States ist hier nicht moeglich, das sowohl der Server als auch der Client Pakete
-# senden koennen, wie Benachrichtigungen und E-Mails
 ## ERLAUBE traffic fuer das IMAP Protokoll
-iptables -A INPUT -p tcp --sport 143 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 143 -j ACCEPT
-iptables -A INPUT -p tcp --sport 993 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 993 -j ACCEPT
+iptables -A INPUT -p tcp --sport 143 -m state --state ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 143 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A INPUT -p tcp --sport 993 -m state --state ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 993 -m state --state NEW,ESTABLISHED -j ACCEPT
 ## ERLAUBE traffic fuer das POP3 Protokoll
-iptables -A INPUT -p tcp --sport 110 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 110 -j ACCEPT
-iptables -A INPUT -p tcp --sport 995 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 995 -j ACCEPT
+iptables -A INPUT -p tcp --sport 110 -m state --state ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 110 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A INPUT -p tcp --sport 995 -m state --state ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 995 -m state --state NEW,ESTABLISHED -j ACCEPT
 ## ERLAUBE traffic fuer das SMTP Protokoll
-iptables -A INPUT -p tcp --sport 587 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 587 -j ACCEPT
+iptables -A INPUT -p tcp --sport 587 -m state --state ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 587 -m state --state NEW,ESTABLISHED -j ACCEPT
 
 # ERLAUBE traffic fuer TeamViewer ueber TCP und UDP
-# ERLAUBE alle Pakete unabhaengig von Status, da dies zu Problem fuehren koennte
-iptables -A INPUT -p tcp --dport 5938 -j ACCEPT
-iptables -A OUTPUT -p tcp --sport 5938 -j ACCEPT
-
-iptables -A INPUT -p udp --dport 5938 -j ACCEPT
-iptables -A OUTPUT -p udp --sport 5938 -j ACCEPT
+iptables -A INPUT -p tcp --dport 5938 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --sport 5938 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -p udp --dport 5938 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p udp --sport 5938 -m state --state ESTABLISHED -j ACCEPT
 
 # ERLAUBE traffic fuer Delftship Lizenzserver
 # ERLAUBE eingehende Pakete vom Lizenzserver
@@ -83,8 +79,7 @@ iptables -A OUTPUT -m state --state NEW,ESTABLISHED -p tcp --dport 8081 -j ACCEP
 # REGELN FÜR ALLE PAKETE DIE VORHERIGE REGELN NICHT MATCHEN
 # LASSE alle eingehenden Pakete FALLEN
 iptables -P INPUT DROP
-# LEITE Pakete WEITER, muss auf Accept sein um Forwarding generell zu ermoeglichen
-iptables -P FORWARD ACCEPT
+# LEITE keine Pakete WEITER
+iptables -P FORWARD DROP
 # LASSE alle ausgehenden Pakete FALLEN
 iptables -P OUTPUT DROP
-


### PR DESCRIPTION
> Das Verwenden von States ist hier (externer Outlook Exchange Server) nicht moeglich, das sowohl der Server als auch der Client Pakete senden koennen, wie Benachrichtigungen und E-Mails

- IMAP, POP3 und SMTP basieren auf TCP und sind verbindungsorientiert
  - Verbindung wird aufgebaut 
  - Daten können bidirektional fließen

- State-Tracking erkennt bestehende Verbindungen (ESTABLISHED)
  - Server-initiierte Pakete (z.B. Benachrichtigungen) gehören zu bestehender Verbindung
  - Werden als ESTABLISHED erkannt und ohne zusätzliche Regeln durchgelassen

> ERLAUBE alle Pakete (Teamviewer) unabhaengig von Status, da dies zu Problem fuehren koennte

- Ähnliches Problem wie oben: ohne State-Tracking werden alle Pakete auf Port 5938 erlaubt, unabhängig von Verbindungszustand.

Ich habe auch im Internet keine weiteren spezifischen Probleme mit iptables und State-Tracking gefunden, auch auf deren [Website](https://www.teamviewer.com/de/global/support/knowledge-base/teamviewer-classic/troubleshooting/ports-used-by-teamviewer/) ist nichts zu finden.

> LEITE eingehenden traffic auf Port 80 WEITER zum Webserver und zurueck

- State-Tracking ist für die nachfolgende Änderung notwendig -> neue Regel: `iptables -A FORWARD -p tcp -d 192.168.0.221 --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT`

- Wenn die FORWARD-Regel für den Webserver spezifisch genug ist, werden alle erwünschten Pakete darüber abgedeckt, also sollte die default policy von `iptables -P FORWARD ACCEPT` zu `iptables -P FORWARD DROP` geändert werden.
